### PR TITLE
Untracked: Avoid lazy loading proxies on Android

### DIFF
--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FontAwesome.WPF" Version="4.7.0.9" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="WpfMessageBox" Version="1.2.0" />

--- a/Mobile/MauiProgram.cs
+++ b/Mobile/MauiProgram.cs
@@ -5,6 +5,17 @@ namespace Carmen.Mobile
 {
     public static class MauiProgram
     {
+        // Some weird bug with EFCore6 and net8 causes LazyLoadProxies to crash with InvalidCastException in PreloadModel (worked fine in EFCore5 and net7)
+        // The most similar bug I could find was: https://github.com/dotnet/efcore/issues/26602
+        // But in this case it crashes in: Castle.DynamicProxy.Internal.AttributeUtil.ReadAttributeValue(CustomAttributeTypedArgument argument)
+        // And the most weird part- ONLY IN ANDROID (but works in Windows)
+        // So the best I could manage was to disable LazyLoadProxies in Android.
+#if !ANDROID
+        public const bool USE_LAZY_LOAD_PROXIES = true;
+#else
+        public const bool USE_LAZY_LOAD_PROXIES = false;
+#endif
+
         public static MauiApp CreateMauiApp()
         {
             var builder = MauiApp.CreateBuilder();

--- a/Mobile/Mobile.csproj
+++ b/Mobile/Mobile.csproj
@@ -112,10 +112,10 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Maui.Controls" Version="8.0.90" />
+    <PackageReference Update="Microsoft.Maui.Controls" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.90" />
+    <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/Mobile/Mobile.csproj
+++ b/Mobile/Mobile.csproj
@@ -96,7 +96,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 

--- a/Mobile/Views/ApplicantDetails.cs
+++ b/Mobile/Views/ApplicantDetails.cs
@@ -123,7 +123,7 @@ namespace Carmen.Mobile.Views
         private async void ViewApplicant_Loaded(object? sender, EventArgs e)
         {
             context = ShowContext.Open(show, MauiProgram.USE_LAZY_LOAD_PROXIES);
-            var applicant = await Task.Run(() => context.Applicants.SingleOrDefault(a => a.ApplicantId == model.ApplicantId));
+            var applicant = await Task.Run(() => context.Applicants.Include(a => a.Notes).SingleOrDefault(a => a.ApplicantId == model.ApplicantId));
             if (applicant == null)
             {
                 DisplayAlert("Applicant does not exist", "This is probably because someone else has deleted them.", "Ok");

--- a/Mobile/Views/ApplicantDetails.cs
+++ b/Mobile/Views/ApplicantDetails.cs
@@ -134,7 +134,7 @@ namespace Carmen.Mobile.Views
             model.Loaded(applicant, criterias);
             ImageSource? source;
             if (applicant.PhotoImageId is int image_id)
-                source = await CachedImage(image_id, applicant.ShowRoot, () => applicant.Photo ?? throw new ApplicationException("Applicant photo not set, but photo ID was."));
+                source = await CachedImage(image_id, applicant.ShowRoot, () => context.Images.Where(i => i.ImageId == image_id).Single() ?? throw new ApplicationException("Applicant photo not set, but photo ID was."));
             else if (await Task.Run(() => applicant.Photo) is SM.Image image)
                 source = await ActualImage(image);
             else

--- a/Mobile/Views/ApplicantDetails.cs
+++ b/Mobile/Views/ApplicantDetails.cs
@@ -122,7 +122,7 @@ namespace Carmen.Mobile.Views
 
         private async void ViewApplicant_Loaded(object? sender, EventArgs e)
         {
-            context = ShowContext.Open(show);
+            context = ShowContext.Open(show, MauiProgram.USE_LAZY_LOAD_PROXIES);
             var applicant = await Task.Run(() => context.Applicants.SingleOrDefault(a => a.ApplicantId == model.ApplicantId));
             if (applicant == null)
             {

--- a/Mobile/Views/ApplicantList.cs
+++ b/Mobile/Views/ApplicantList.cs
@@ -109,7 +109,7 @@ namespace Carmen.Mobile.Views
 
         private async void ApplicantList_Loaded(object? sender, EventArgs e)
         {
-            context = ShowContext.Open(show);
+            context = ShowContext.Open(show, MauiProgram.USE_LAZY_LOAD_PROXIES);
             var collection = await context.Applicants.ToArrayAsync();
             model.Loaded(collection, sortBy);
         }

--- a/Mobile/Views/CastList.cs
+++ b/Mobile/Views/CastList.cs
@@ -94,7 +94,7 @@ namespace Carmen.Mobile.Views
             context = ShowContext.Open(show, MauiProgram.USE_LAZY_LOAD_PROXIES);
             var criterias = await context.Criterias.ToArrayAsync();
             var tags = await context.Tags.ToArrayAsync();
-            var collection = await context.Applicants.Where(a => a.CastGroup != null).ToArrayAsync();
+            var collection = await context.Applicants.Include(a => a.Roles).ThenInclude(r => r.Items).Where(a => a.CastGroup != null).ToArrayAsync();
             model.Loaded(collection, criterias, tags);
         }
 
@@ -135,7 +135,7 @@ namespace Carmen.Mobile.Views
             await Navigation.PushAsync(new BasicList<ItemRole>($"Roles for {applicant.FirstName} {applicant.LastName}", "No roles allocated", () =>
             {
                 context.Nodes.Load();
-                var roles = applicant.Roles.ToArray();//TODO wont work without lazy loading (applicant.Roles, role.Items)
+                var roles = applicant.Roles.ToArray();
                 var item_roles = new List<ItemRole>();
                 foreach (var item in context.ShowRoot.ItemsInOrder())
                     foreach (var role in roles.Where(r => r.Items.Contains(item)))

--- a/Mobile/Views/CastList.cs
+++ b/Mobile/Views/CastList.cs
@@ -135,7 +135,7 @@ namespace Carmen.Mobile.Views
             await Navigation.PushAsync(new BasicList<ItemRole>($"Roles for {applicant.FirstName} {applicant.LastName}", "No roles allocated", () =>
             {
                 context.Nodes.Load();
-                var roles = applicant.Roles.ToArray();
+                var roles = applicant.Roles.ToArray();//TODO wont work without lazy loading (applicant.Roles, role.Items)
                 var item_roles = new List<ItemRole>();
                 foreach (var item in context.ShowRoot.ItemsInOrder())
                     foreach (var role in roles.Where(r => r.Items.Contains(item)))

--- a/Mobile/Views/CastList.cs
+++ b/Mobile/Views/CastList.cs
@@ -91,7 +91,7 @@ namespace Carmen.Mobile.Views
 
         private async void CastList_Loaded(object? sender, EventArgs e)
         {
-            context = ShowContext.Open(show);
+            context = ShowContext.Open(show, MauiProgram.USE_LAZY_LOAD_PROXIES);
             var criterias = await context.Criterias.ToArrayAsync();
             var tags = await context.Tags.ToArrayAsync();
             var collection = await context.Applicants.Where(a => a.CastGroup != null).ToArrayAsync();

--- a/Mobile/Views/ItemList.cs
+++ b/Mobile/Views/ItemList.cs
@@ -75,6 +75,7 @@ namespace Carmen.Mobile.Views
         {
             context = ShowContext.Open(show, MauiProgram.USE_LAZY_LOAD_PROXIES);
             await context.Nodes.LoadAsync();
+            await context.Nodes.OfType<Item>().Include(i => i.Roles).ThenInclude(r => r.Cast).LoadAsync();
             var items = context.ShowRoot.ItemsInOrder().Select(i => new ItemDetail { Item = i }).ToArray();
             model.Loaded(items);
         }
@@ -100,9 +101,9 @@ namespace Carmen.Mobile.Views
             if (sender is not Cell cell || cell.BindingContext is not ItemDetail item || context == null)
                 return;
             await Navigation.PushAsync(new BasicList<RoleDetail>($"Roles in {item.Item.Name}", "No roles",
-                () => item.Item.Roles.InNameOrder().Select(r => new RoleDetail { Role = r }).ToArray(),//TODO wont work without lazy loading: item.Roles
+                () => item.Item.Roles.InNameOrder().Select(r => new RoleDetail { Role = r }).ToArray(),
                 rd => Navigation.PushAsync(new BasicList<ApplicantDetail>($"Cast for {rd.Role.Name}", "No cast",
-                    () => rd.Role.Cast.OrderBy(c => c.CastNumber).ThenBy(c => c.AlternativeCast?.Initial).Select(c => new ApplicantDetail { Applicant = c }).ToArray()))));//TODO wont work without lazy loading: role.Cast
+                    () => rd.Role.Cast.OrderBy(c => c.CastNumber).ThenBy(c => c.AlternativeCast?.Initial).Select(c => new ApplicantDetail { Applicant = c }).ToArray()))));
         }
     }
 }

--- a/Mobile/Views/ItemList.cs
+++ b/Mobile/Views/ItemList.cs
@@ -73,7 +73,7 @@ namespace Carmen.Mobile.Views
 
         private async void ItemList_Loaded(object? sender, EventArgs e)
         {
-            context = ShowContext.Open(show);
+            context = ShowContext.Open(show, MauiProgram.USE_LAZY_LOAD_PROXIES);
             await context.Nodes.LoadAsync();
             var items = context.ShowRoot.ItemsInOrder().Select(i => new ItemDetail { Item = i }).ToArray();
             model.Loaded(items);

--- a/Mobile/Views/ItemList.cs
+++ b/Mobile/Views/ItemList.cs
@@ -100,9 +100,9 @@ namespace Carmen.Mobile.Views
             if (sender is not Cell cell || cell.BindingContext is not ItemDetail item || context == null)
                 return;
             await Navigation.PushAsync(new BasicList<RoleDetail>($"Roles in {item.Item.Name}", "No roles",
-                () => item.Item.Roles.InNameOrder().Select(r => new RoleDetail { Role = r }).ToArray(),
+                () => item.Item.Roles.InNameOrder().Select(r => new RoleDetail { Role = r }).ToArray(),//TODO wont work without lazy loading: item.Roles
                 rd => Navigation.PushAsync(new BasicList<ApplicantDetail>($"Cast for {rd.Role.Name}", "No cast",
-                    () => rd.Role.Cast.OrderBy(c => c.CastNumber).ThenBy(c => c.AlternativeCast?.Initial).Select(c => new ApplicantDetail { Applicant = c }).ToArray()))));
+                    () => rd.Role.Cast.OrderBy(c => c.CastNumber).ThenBy(c => c.AlternativeCast?.Initial).Select(c => new ApplicantDetail { Applicant = c }).ToArray()))));//TODO wont work without lazy loading: role.Cast
         }
     }
 }

--- a/Mobile/Views/MainMenu.cs
+++ b/Mobile/Views/MainMenu.cs
@@ -130,7 +130,7 @@ namespace Carmen.Mobile.Views
                 model.Error($"Unable to connect to server:\n{connection.Description}\n\n{error}");
                 return;
             }
-            using (var context = ShowContext.Open(connection))
+            using (var context = ShowContext.Open(connection, MauiProgram.USE_LAZY_LOAD_PROXIES))
             {
                 model.Loading("Preparing show model");
                 await context.PreloadModel(); // do this here while the overlay is shown to avoid a synchronous delay when the MainMenu is loaded

--- a/ShowModel/ShowContext.cs
+++ b/ShowModel/ShowContext.cs
@@ -162,7 +162,7 @@ namespace Carmen.ShowModel
             await Task.Run(() => Database.Migrate()); // see EntityFrameworkQueryableExtensionsWithGuaranteedAsync
         }
 
-        public async Task CopyDatabase(ShowConnection overwrite_database, Action<string, string>? progress_callback = null)//TODO confirm never called from Android
+        public async Task CopyDatabase(ShowConnection overwrite_database, Action<string, string>? progress_callback = null)
         {
             Log.Information($"{nameof(ShowContext)}.{nameof(CopyDatabase)}");
             using var destination = Open(overwrite_database);

--- a/ShowModel/ShowContext.cs
+++ b/ShowModel/ShowContext.cs
@@ -104,7 +104,14 @@ namespace Carmen.ShowModel
         /// which takes ~1s synchronously. This runs it in a separate thread to avoid a synchronous delay.</summary>
         public async Task PreloadModel()
         {
-            await Task.Run(() => _ = this.Model);
+            try
+            {
+                await Task.Run(() => _ = this.Model);
+            }
+            catch (Exception ex)
+            {
+                throw new ApplicationException("Failed to preload model", ex);
+            }
         }
 
         public async Task CreateNewDatabase(string default_show_name)

--- a/ShowModel/Structure/Node.cs
+++ b/ShowModel/Structure/Node.cs
@@ -91,7 +91,7 @@ namespace Carmen.ShowModel.Structure
             ?? ItemsInOrder().SelectMany(i => i.Roles).Distinct().Select(r => r.CountFor(group)).Sum();
 
         /// <summary>Recursively enumerate all parents</summary>
-        public IEnumerable<InnerNode> Parents()
+        public IEnumerable<InnerNode> Parents()//TODO wont work without lazy loading
         {
             var parent = Parent;
             while (parent != null)

--- a/ShowModel/Structure/Node.cs
+++ b/ShowModel/Structure/Node.cs
@@ -91,7 +91,7 @@ namespace Carmen.ShowModel.Structure
             ?? ItemsInOrder().SelectMany(i => i.Roles).Distinct().Select(r => r.CountFor(group)).Sum();
 
         /// <summary>Recursively enumerate all parents</summary>
-        public IEnumerable<InnerNode> Parents()//TODO wont work without lazy loading
+        public IEnumerable<InnerNode> Parents()
         {
             var parent = Parent;
             while (parent != null)


### PR DESCRIPTION
Workaround for a very weird bug with EFCore6 and net8-android

```
   at Castle.DynamicProxy.Internal.AttributeUtil.ReadAttributeValue(CustomAttributeTypedArgument argument)
   at Castle.DynamicProxy.Internal.AttributeUtil.GetArguments(IList`1 constructorArguments, Type[]& constructorArgTypes, Object[]& constructorArgs)
   at Castle.DynamicProxy.Internal.AttributeUtil.CreateInfo(CustomAttributeData attribute)
   at Castle.DynamicProxy.Internal.AttributeUtil.GetNonInheritableAttributes(ParameterInfo parameter)+MoveNext()
   at Castle.DynamicProxy.Generators.BaseProxyGenerator.GenerateConstructor(ClassEmitter emitter, ConstructorInfo baseConstructor, FieldReference[] fields)
   at Castle.DynamicProxy.Generators.BaseProxyGenerator.GenerateConstructors(ClassEmitter emitter, Type baseType, FieldReference[] fields)
   at Castle.DynamicProxy.Generators.ClassProxyGenerator.GenerateType(String name, Type[] interfaces, INamingScope namingScope)
   at Castle.DynamicProxy.Generators.ClassProxyGenerator.<>c__DisplayClass1_0.<GenerateCode>b__0(String n, INamingScope s)
   at Castle.DynamicProxy.Generators.BaseProxyGenerator.<>c__DisplayClass33_0.<ObtainProxyType>b__0(CacheKey _)
   at Castle.Core.Internal.SynchronizedDictionary`2[[Castle.DynamicProxy.Generators.CacheKey, Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc],[System.Type, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].GetOrAdd(CacheKey key, Func`2 valueFactory)
   at Castle.DynamicProxy.Generators.BaseProxyGenerator.ObtainProxyType(CacheKey cacheKey, Func`3 factory)
   at Castle.DynamicProxy.Generators.ClassProxyGenerator.GenerateCode(Type[] interfaces, ProxyGenerationOptions options)
   at Castle.DynamicProxy.DefaultProxyBuilder.CreateClassProxyType(Type classToProxy, Type[] additionalInterfacesToProxy, ProxyGenerationOptions options)
   at Microsoft.EntityFrameworkCore.Proxies.Internal.ProxyFactory.CreateProxyType(ProxiesOptionsExtension options, IReadOnlyEntityType entityType)
   at Microsoft.EntityFrameworkCore.Proxies.Internal.ProxyBindingRewriter.ProcessModelFinalizing(IConventionModelBuilder modelBuilder, IConventionContext`1 context)
   at Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.ConventionDispatcher.ImmediateConventionScope.OnModelFinalizing(IConventionModelBuilder modelBuilder)
   at Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.ConventionDispatcher.OnModelFinalizing(IConventionModelBuilder modelBuilder)
   at Microsoft.EntityFrameworkCore.Metadata.Internal.Model.FinalizeModel()
   at Microsoft.EntityFrameworkCore.Infrastructure.ModelRuntimeInitializer.Initialize(IModel model, Boolean designTime, IDiagnosticsLogger`1 validationLogger)
   at Microsoft.EntityFrameworkCore.Infrastructure.ModelSource.GetModel(DbContext context, ModelCreationDependencies modelCreationDependencies, Boolean designTime)
   at Microsoft.EntityFrameworkCore.Internal.DbContextServices.CreateModel(Boolean designTime)
   at Microsoft.EntityFrameworkCore.Internal.DbContextServices.get_Model()
   at Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkServicesBuilder.<>c.<TryAddCoreServices>b__8_4(IServiceProvider p)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSiteMain(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScopeCache(ServiceCallSite callSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSite(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSiteMain(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScopeCache(ServiceCallSite callSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSite(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSiteMain(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScopeCache(ServiceCallSite callSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSite(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSiteMain(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScopeCache(ServiceCallSite callSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSite(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSiteMain(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScopeCache(ServiceCallSite callSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSite(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSiteMain(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitCache(ServiceCallSite callSite, RuntimeResolverContext context, ServiceProviderEngineScope serviceProviderEngine, RuntimeResolverLock lockType)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScopeCache(ServiceCallSite callSite, RuntimeResolverContext context)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeResolverContext, Microsoft.Extensions.DependencyInjection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Object, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].VisitCallSite(ServiceCallSite callSite, RuntimeResolverContext argument)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.RuntimeServiceProviderEngine.<>c__DisplayClass4_0.<RealizeService>b__0(ServiceProviderEngineScope scope)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[IDbContextDependencies](IServiceProvider provider)
   at Microsoft.EntityFrameworkCore.DbContext.get_DbContextDependencies()
   at Microsoft.EntityFrameworkCore.DbContext.get_ContextServices()
   at Microsoft.EntityFrameworkCore.DbContext.get_Model()
   at Carmen.ShowModel.ShowContext.<PreloadModel>b__34_0() in C:\Users\David Lang\Source\Repos\Carmen\ShowModel\ShowContext.cs:line 107
   at System.Threading.Tasks.Task`1[[Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore, Version=6.0.33.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__281_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at Carmen.ShowModel.ShowContext.PreloadModel() in C:\Users\David Lang\Source\Repos\Carmen\ShowModel\ShowContext.cs:line 107
```