### PR TITLE
Untracked: EFcore model creation on macOS

### DIFF
--- a/Mobile/Mobile.csproj
+++ b/Mobile/Mobile.csproj
@@ -65,6 +65,7 @@
 	<CodesignEntitlements>Platforms\MacCatalyst\Entitlements.plist</CodesignEntitlements>
 	<PackageSigningKey>Developer ID Installer: David Lang (45435R99CA)</PackageSigningKey>
 	<UseHardenedRuntime>true</UseHardenedRuntime>
+	<RuntimeIdentifier>maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-ios')) and '$(Configuration)' == 'Release'">

--- a/Mobile/build_for_mac.sh
+++ b/Mobile/build_for_mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 dotnet publish -f net7.0-maccatalyst -c Release
-PKG_FILE="`ls -1 ./bin/Release/net7.0-maccatalyst/publish/Carmen.Mobile*.pkg | tail -n 1`"
+PKG_FILE="`ls -1 ./bin/Release/net7.0-maccatalyst/maccatalyst-x64/publish/Carmen.Mobile*.pkg | tail -n 1`"
 echo Press ENTER to submit to Apple: $PKG_FILE
 read
 xcrun notarytool submit $PKG_FILE --wait --apple-id davidlang42@gmail.com --team-id 45435R99CA # this will prompt for an AppleID app specific password


### PR DESCRIPTION
When built for macos-arm64, efcore hangs when making the model, so force build for macos-x64 only